### PR TITLE
add version to filename output

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function getPackageInfo(packageFile) {
 
 function getDefaultOuputFilename({ cwd }) {
     const packageFile = path.join(cwd, 'package.json');
-    return getPackageInfo(packageFile).then(packageInfo => `${sanitize(packageInfo.name)}.zip`);
+    return getPackageInfo(packageFile).then(packageInfo => `${sanitize(packageInfo.name)}-${packageInfo.version}.zip`);
 };
 
 function zipFiles(files, filename, source, destination, info, verbose) {


### PR DESCRIPTION
To keep consistant with `npm pack` which formats its filename as `<name>-<version>.tgz`