### PR TITLE
Implement extra argument static-date-modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,20 @@ Create the .zip file containing _my-lambda_ and its dependencies, ready to uploa
 ```
 npm run pack
 ```
+
+### Static date modified of the files inside the zip
+If you need to create `*.zip` package with static date modified of the files inside then you can use the flag `--static-date-modified` . This can be used if you are using automation deployment to the AWS, where the server checkouts the code (brand new) each time deployment is triggered. Hash can be calculated so that you can check with the hash in AWS so that you can check if the code is changed.
+
+```
+"scripts": {
+    "pack": "npm-pack-zip --static-date-modified"
+    ...
+}
+```
+
+```
+"scripts": {
+    "pack": "npm-pack-zip --sdm"
+    ...
+}
+```

--- a/bin/npm-pack-zip.js
+++ b/bin/npm-pack-zip.js
@@ -27,6 +27,10 @@ const argv = require('yargs')
     alias: 'v',
     default: false,
   })
+  .option('static-date-modified', {
+    alias: 'sdm',
+    default: false,
+  })
   .argv;
 
 const source = argv.source;
@@ -34,7 +38,8 @@ const destination = argv.destination;
 const info = argv.info;
 const verbose = argv.verbose;
 const addVersion = argv.addVersion;
-pack({source, destination, info, verbose, addVersion})
+const staticDateModified = argv.staticDateModified;
+pack({source, destination, info, verbose, addVersion, staticDateModified})
   .then(() => process.exit(0))
   .catch(error => {
     console.error(error);

--- a/index.js
+++ b/index.js
@@ -20,23 +20,23 @@ function getDefaultOutputFilename({ cwd, addVersion }) {
     return getPackageInfo(packageFile).then(packageInfo => `${sanitize(packageInfo.name)}${(addVersion) ? '-'+sanitize(packageInfo.version) : ''}.zip`);
 };
 
-function zipFiles(files, filename, source, destination, info, verbose) {
+function zipFiles(files, filename, source, destination, info, verbose, staticDateModified) {
     const target = path.join(destination, filename);
     if (info)
-        console.log(`Archive: ${target}`);
+        console.log(`Archive: ${target} with staticDateModifiedFlag: ${String(staticDateModified)}`);
 
     let archive = archiver(target);
     files.forEach(file => {
         const filePath = path.join(source, file);
         if (verbose)
             console.log(file);
-        archive.file(filePath, { name: file });
+        archive.file(filePath, { name: file, date: staticDateModified ? new Date(2000, 0) : void 0 });
     });
 
     return archive.finalize();
 };
 
-function pack({ source, destination, info, verbose, addVersion }) {
+function pack({ source, destination, info, verbose, addVersion, staticDateModified }) {
     return packlist({ path: source })
         .then(files => {
             return getDefaultOutputFilename({ cwd: source, addVersion })
@@ -44,7 +44,7 @@ function pack({ source, destination, info, verbose, addVersion }) {
                     if (destination && !fs.existsSync(destination)){
                         fs.mkdirSync(destination);
                     }
-                    return zipFiles(files, filename, source, destination, info, verbose);
+                    return zipFiles(files, filename, source, destination, info, verbose, staticDateModified);
                 });
         });
 };


### PR DESCRIPTION
For automation deployment where we checkout daily the code in order to get the same HASH for comparing is the code changed with the one already deployed on the AWS we need to have static timestamp of the files when they are zipped.

AWS lambda service is generating HASH from the code and we are using that to compare is the code different